### PR TITLE
Quick JORFile implementation

### DIFF
--- a/MCHI/JORServer.cs
+++ b/MCHI/JORServer.cs
@@ -768,8 +768,8 @@ namespace MCHI
 
         public void ProcessJORFileCommand(MemoryInputStream stream)
         {
-            var command = stream.ReadU32(); // 0x00 
-            switch (command) // ♪ we're gonna show you how to behave ♪
+            var command = stream.ReadU32(); 
+            switch (command) 
             {
                 case (uint)JORFileCommand.OPEN:
                     {


### PR DESCRIPTION
At least accept and respond to JORFile commands so we can feel safe clicking buttons. 

If a JORFile command button is clicked, the emulator should print 

```Core\HW\EXI\EXI_DeviceIPL.cpp:327 N[OSREPORT]: Close Failed!```

